### PR TITLE
fix(calc): include zero-hour prefix when formatting time

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -153,21 +153,20 @@ export function formatTime(seconds, includeHours = false, allowMultiday = false)
 		return `${days} ${dayText} ${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
 	}
 
-	// Single-day formatting
-	if (includeHours && totalSeconds >= SECONDS_PER_HOUR) {
-		// For times ≥ 1 hour, show HH:MM:SS
-		const totalHours = Math.floor(totalSeconds / SECONDS_PER_HOUR);
-		const remainingMinutes = Math.floor((totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
-		const remainingSecs = totalSeconds % SECONDS_PER_MINUTE;
+        // Single-day formatting
+        if (includeHours) {
+                const totalHours = Math.floor(totalSeconds / SECONDS_PER_HOUR);
+                const remainingMinutes = Math.floor((totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+                const remainingSecs = totalSeconds % SECONDS_PER_MINUTE;
 
-		return `${String(totalHours).padStart(2, "0")}:${String(remainingMinutes).padStart(2, "0")}:${String(remainingSecs).padStart(2, "0")}`;
-	}
+                return `${String(totalHours).padStart(2, "0")}:${String(remainingMinutes).padStart(2, "0")}:${String(remainingSecs).padStart(2, "0")}`;
+        }
 
-	// For times < 1 hour, show MM:SS (with total minutes if > 59)
-	const totalMinutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
-	const remainingSecs = totalSeconds % SECONDS_PER_MINUTE;
+        // For times < 1 hour or when hours aren't requested, show MM:SS
+        const totalMinutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
+        const remainingSecs = totalSeconds % SECONDS_PER_MINUTE;
 
-	return `${String(totalMinutes).padStart(2, "0")}:${String(remainingSecs).padStart(2, "0")}`;
+        return `${String(totalMinutes).padStart(2, "0")}:${String(remainingSecs).padStart(2, "0")}`;
 }
 
 export function calculatePace(totalSeconds, distance, unit) {

--- a/tests/unit/calculator.test.js
+++ b/tests/unit/calculator.test.js
@@ -226,9 +226,9 @@ describe('Calculator Core Functions', () => {
         expect(formatTime(86399, true)).toBe('23:59:59') // 23:59:59
       })
 
-      it('should use MM:SS format when no hours even if includeHours=true', () => {
-        expect(formatTime(270, true)).toBe('04:30')
-        expect(formatTime(3599, true)).toBe('59:59')
+      it('should include hours when requested even if zero', () => {
+        expect(formatTime(270, true)).toBe('00:04:30')
+        expect(formatTime(3599, true)).toBe('00:59:59')
       })
     })
 

--- a/tests/unit/pr.test.js
+++ b/tests/unit/pr.test.js
@@ -62,7 +62,7 @@ vi.mock('../../src/calculator.js', () => ({
     return { valid: true, value: minutes * 60 }
   }),
   formatTime: vi.fn((seconds, includeHours = false) => {
-    if (includeHours && seconds >= 3600) {
+    if (includeHours) {
       const hours = Math.floor(seconds / 3600)
       const mins = Math.floor((seconds % 3600) / 60)
       const secs = seconds % 60
@@ -325,7 +325,7 @@ describe('Personal Records (PR) Module', () => {
       expect(result).toHaveLength(3)
       expect(result[0].distanceKm).toBe(5)
       expect(result[0].displayName).toBe('5K') // Standard distance
-      expect(result[0].timeFormatted).toBe('20:00') // Mocked format
+      expect(result[0].timeFormatted).toBe('00:20:00') // Mocked format
       
       expect(result[2].distanceKm).toBe(10) // Should be sorted by distance
       expect(result[2].displayName).toBe('10K')


### PR DESCRIPTION
## Summary
- ensure `formatTime` shows `00:` prefix when `includeHours` is true
- update unit tests for new `formatTime` behavior

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c141cc97c08332b1b6ae6ac611cf1d