### PR TITLE
fix: round decimal time input

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -20,11 +20,11 @@ export function parseTime(timeStr) {
 
 	// Handle decimal format (e.g., "4.5" = 4:30)
 	if (/^\d+(\.\d+)?$/.test(trimmed)) {
-		const decimal = parseFloat(trimmed);
-		const minutes = Math.floor(decimal);
-		const seconds = Math.floor((decimal - minutes) * SECONDS_PER_MINUTE);
-		return minutes * SECONDS_PER_MINUTE + seconds;
-	}
+                const decimal = parseFloat(trimmed);
+                const minutes = Math.floor(decimal);
+                const seconds = Math.round((decimal - minutes) * SECONDS_PER_MINUTE);
+                return minutes * SECONDS_PER_MINUTE + seconds;
+        }
 
 	// Handle space-separated format (e.g., "4 30" = 4:30 or "2 1 23 45" = 2 days 1:23:45)
 	if (/^\d+\s+\d+(\s+\d+)?(\s+\d+)?$/.test(trimmed)) {

--- a/tests/unit/calculator.test.js
+++ b/tests/unit/calculator.test.js
@@ -27,6 +27,11 @@ describe('Calculator Core Functions', () => {
         expect(parseTime('0')).toBe(0)
         expect(parseTime('1')).toBe(60)
       })
+
+      it('should round fractional seconds to nearest whole second', () => {
+        expect(parseTime('4.999')).toBe(300)
+        expect(parseTime('4.001')).toBe(240)
+      })
     })
 
     describe('colon format', () => {


### PR DESCRIPTION
## Summary
- round decimal time parsing to nearest second
- add tests for fractional decimal parsing

## Testing
- `npm run lint` *(fails: design token violations)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c14a3581008332a42e128036e66697