### PR TITLE
feat(ui): announce clipboard copy for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,24 +478,25 @@
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
 							</svg>
 						</button>
-						<button
-							id="copy-result-btn"
-							class="p-1.5 transition-colors rounded-md"
-							style="color: var(--color-text-tertiary);"
-							aria-label="Copy result to clipboard"
-							title="Copy result to clipboard"
-						>
-						<svg id="copy-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-						</svg>
-						<svg id="check-icon" class="w-4 h-4 hidden" style="color: var(--color-status-success);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-						</svg>
-					</button>
-				</div>
-			</div>
+                                                <button
+                                                        id="copy-result-btn"
+                                                        class="p-1.5 transition-colors rounded-md"
+                                                        style="color: var(--color-text-tertiary);"
+                                                        aria-label="Copy result to clipboard"
+                                                        title="Copy result to clipboard"
+                                                >
+                                                <svg id="copy-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                                </svg>
+                                                <svg id="check-icon" class="w-4 h-4 hidden" style="color: var(--color-status-success);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                                </svg>
+                                        </button>
+                                        <span id="copy-feedback" class="sr-only" role="status" aria-live="polite"></span>
+                                </div>
+                        </div>
 
-			<!-- Loading State -->
+                        <!-- Loading State -->
 			<div id="loading" class="mt-6 p-4 rounded-lg hidden">
 				<div class="flex items-center justify-center space-x-2">
 					<div class="animate-spin rounded-full h-6 w-6 border-b-2" style="border-color: var(--color-interactive-primary);"></div>

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@ import { state } from "./state.js";
 
 
 // DOM Elements (will be initialized in initUI)
-let form, resultDiv, resultLabel, resultValue, loadingDiv, copyBtn, copyIcon, checkIcon, savePrBtn, updatePrBtn;
+let form, resultDiv, resultLabel, resultValue, loadingDiv, copyBtn, copyIcon, checkIcon, copyFeedback, savePrBtn, updatePrBtn;
 
 // Segmented input utility functions - simplified to allow unlimited hours
 function getSegmentedTimeValue(prefix) {
@@ -605,9 +605,14 @@ function generateComprehensiveResult() {
 }
 
 function animateCopySuccess() {
-	// Animate copy icon out
-	copyIcon.classList.add('animate-icon-transition-out');
-	copyBtn.classList.add('animate-pulse-success');
+        // Animate copy icon out
+        copyIcon.classList.add('animate-icon-transition-out');
+        copyBtn.classList.add('animate-pulse-success');
+
+        // Announce copy success for assistive technologies
+        if (copyFeedback) {
+                copyFeedback.textContent = 'Result copied to clipboard';
+        }
 
 	// After copy icon fades out, show checkmark with animation
 	setTimeout(() => {
@@ -617,11 +622,11 @@ function animateCopySuccess() {
 		checkIcon.classList.add('animate-icon-transition-in');
 	}, 200);
 
-	// Reset after 2 seconds total
-	setTimeout(() => {
-		// Animate checkmark out
-		checkIcon.classList.remove('animate-icon-transition-in');
-		checkIcon.classList.add('animate-icon-transition-out');
+        // Reset after 2 seconds total
+        setTimeout(() => {
+                // Animate checkmark out
+                checkIcon.classList.remove('animate-icon-transition-in');
+                checkIcon.classList.add('animate-icon-transition-out');
 
 		// After checkmark fades out, show copy icon with animation
 		setTimeout(() => {
@@ -631,12 +636,19 @@ function animateCopySuccess() {
 			copyIcon.classList.add('animate-icon-transition-in');
 			copyBtn.classList.remove('animate-pulse-success');
 
-			// Clean up animation class
-			setTimeout(() => {
-				copyIcon.classList.remove('animate-icon-transition-in');
-			}, 200);
-		}, 200);
-	}, 2000);
+                        // Clean up animation class
+                        setTimeout(() => {
+                                copyIcon.classList.remove('animate-icon-transition-in');
+                        }, 200);
+                }, 200);
+        }, 2000);
+
+        // Clear live region message after announcement
+        if (copyFeedback) {
+                setTimeout(() => {
+                        copyFeedback.textContent = '';
+                }, 2000);
+        }
 }
 
 async function copyToClipboard(text) {
@@ -1350,17 +1362,18 @@ async function coreInitUI() {
 
 
 	// Get all required DOM elements with error handling
-	const elementIds = [
-		'calculator-form',
-		'result',
-		'result-label',
-		'result-value',
-		'loading',
-		'copy-result-btn',
-		'copy-icon',
-		'check-icon',
-		'clear-btn'
-	];
+        const elementIds = [
+                'calculator-form',
+                'result',
+                'result-label',
+                'result-value',
+                'loading',
+                'copy-result-btn',
+                'copy-icon',
+                'check-icon',
+                'clear-btn',
+                'copy-feedback'
+        ];
 
 	const optionalElementIds = [
 		'save-pr-btn',
@@ -1379,9 +1392,10 @@ async function coreInitUI() {
 	resultLabel = elements['result-label'];
 	resultValue = elements['result-value'];
 	loadingDiv = elements['loading'];
-	copyBtn = elements['copy-result-btn'];
-	copyIcon = elements['copy-icon'];
-	checkIcon = elements['check-icon'];
+        copyBtn = elements['copy-result-btn'];
+        copyIcon = elements['copy-icon'];
+        checkIcon = elements['check-icon'];
+        copyFeedback = elements['copy-feedback'];
 	savePrBtn = optionalElements['save-pr-btn'];
 	updatePrBtn = optionalElements['update-pr-btn'];
 

--- a/tests/unit/tabs.test.js
+++ b/tests/unit/tabs.test.js
@@ -103,6 +103,7 @@ describe('Tab Functionality', () => {
           <svg id="copy-icon"></svg>
           <svg id="check-icon" class="hidden"></svg>
         </button>
+        <span id="copy-feedback" role="status" aria-live="polite"></span>
         <button id="clear-btn">Clear</button>
         <button id="save-pr-btn" class="hidden">Save PR</button>
         <button id="update-pr-btn" class="hidden">Update PR</button>


### PR DESCRIPTION
## Summary
- add hidden live region to announce result copy events for screen readers
- update UI logic to populate copy-feedback and clear after delay
- extend tab tests for new live region element

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c14cc127188332a4e080f05fb45312