### PR TITLE
fix: ensure personal records modal opens via menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,13 +136,13 @@
 						<div id="menu-dropdown" class="absolute top-full left-0 mt-2 w-48 hidden z-50">
 							<div class="dropdown-content rounded-lg shadow-lg overflow-hidden">
 								<div class="py-1">
-									<button id="pr-menu-item" class="btn-menu flex items-center">
+                                                                        <button id="pr-menu-item" type="button" class="btn-menu flex items-center">
 										<svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
 											<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
 										</svg>
 										<span>Personal Records</span>
 									</button>
-									<button id="settings-menu-item" class="btn-menu flex items-center">
+                                                                        <button id="settings-menu-item" type="button" class="btn-menu flex items-center">
 										<svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>


### PR DESCRIPTION
## Summary
- prevent menu items from acting as submit buttons
- ensure Personal Records modal opens correctly

## Testing
- `npm run test:run`
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c16230e8348332a85bfb3f09000088