### PR TITLE
fix(settings): apply default distance on load

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -138,6 +138,9 @@ function applyDistanceUnit(unit) {
 
     // Update default distance dropdown if in settings modal
     populateDefaultDistanceSelect();
+
+    // Apply default distance whenever unit changes
+    applyDefaultDistance();
 }
 
 // Populate default distance dropdown based on current unit
@@ -166,9 +169,12 @@ function handleDefaultDistanceChange(e) {
 	const selectedPreset = e.target.value;
 
 	// Save the setting immediately
-	const currentSettings = loadSettings();
-	currentSettings.defaultDistance = selectedPreset || null;
-	saveSettings(currentSettings);
+        const currentSettings = loadSettings();
+        currentSettings.defaultDistance = selectedPreset || null;
+        saveSettings(currentSettings);
+
+        // Immediately apply the selected default distance
+        applyDefaultDistance();
 }
 
 // Apply default distance to all distance input fields if set

--- a/tests/unit/default-distance.test.js
+++ b/tests/unit/default-distance.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../src/ui.js', () => ({
+  populatePresetSelects: vi.fn(),
+  updateCalculatedResult: vi.fn(),
+  updateHintTexts: vi.fn(),
+}))
+
+vi.mock('../../src/pr.js', () => ({
+  getAllPRs: vi.fn(() => []),
+  getPRForDistance: vi.fn(() => null),
+  comparePaceWithPR: vi.fn(() => null),
+  getDistanceName: vi.fn(() => ''),
+}))
+
+vi.mock('../../src/calculator.js', () => ({
+  formatDistance: vi.fn(d => d),
+}))
+
+describe('Default distance', () => {
+  beforeEach(() => {
+    // Stub matchMedia for jsdom
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+
+    localStorage.clear()
+    localStorage.setItem('pace-calculator-settings', JSON.stringify({
+      distanceUnit: 'km',
+      defaultDistance: '5k',
+      theme: 'system',
+      accentColor: 'indigo',
+    }))
+
+    document.body.innerHTML = `
+      <div id="settings-modal"></div>
+      <div id="help-modal"></div>
+      <div id="pr-management-modal"></div>
+      <div id="pr-modal"></div>
+      <select id="default-distance-select"></select>
+      <input id="pace-distance" />
+      <select id="pace-preset"></select>
+      <input id="time-distance" />
+      <select id="time-preset"></select>
+      <div data-unit="km"></div>
+      <div data-unit="miles"></div>
+    `
+  })
+
+  it('applies saved default distance on init', async () => {
+    const settings = await import('../../src/settings.js')
+    settings.initSettings()
+
+    expect(document.getElementById('pace-distance').value).toBe('5')
+    expect(document.getElementById('time-distance').value).toBe('5')
+    // Preset dropdowns should reflect the saved default if options exist
+    // (test environment has no options, so ensure no crash and inputs are set)
+  })
+})


### PR DESCRIPTION
## Summary
- apply saved default distance whenever unit changes
- reapply default distance immediately after settings updates
- add test verifying default distance persistence

## Testing
- `npm run test:run`
- `npm run lint` *(fails: Design token violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f854842c8332a40d8bd7958091ca