### PR TITLE
fix: handle invalid dates

### DIFF
--- a/src/pr.js
+++ b/src/pr.js
@@ -178,14 +178,16 @@ export function getDistanceName(distance, unit) {
 
 // Format date for display
 export function formatDate(isoString) {
-	if (!isoString) return '';
-	
-	try {
-		const date = new Date(isoString);
-		return date.toLocaleDateString();
-	} catch {
-		return '';
-	}
+        if (!isoString) return '';
+
+        const date = new Date(isoString);
+
+        // If the date is invalid, return the same string Node would produce
+        if (isNaN(date.getTime())) {
+                return 'Invalid Date';
+        }
+
+        return date.toLocaleDateString();
 }
 
 // Get date in YYYY-MM-DD format for date input

--- a/tests/unit/auto-advance.test.js
+++ b/tests/unit/auto-advance.test.js
@@ -218,22 +218,20 @@ describe('Auto-Advance Functionality', () => {
       initAutoAdvance()
     })
 
-    it('should move to previous field on backspace when current field is empty', done => {
+    it('should move to previous field on backspace when current field is empty', () => {
       const hoursInput = document.getElementById('pace-time-hours')
       const minutesInput = document.getElementById('pace-time-minutes')
-      
+
       // Mock focus and selection methods
-      hoursInput.focus = vi.fn(() => {
-        // Test that focus was called
-        expect(hoursInput.focus).toHaveBeenCalled()
-        done()
-      })
+      hoursInput.focus = vi.fn()
       hoursInput.setSelectionRange = vi.fn()
       hoursInput.value = '02' // Set some value to move cursor to end
-      
+
       // Clear minutes input and press backspace
       minutesInput.value = ''
       fireEvent.keyDown(minutesInput, { key: 'Backspace' })
+
+      expect(hoursInput.focus).toHaveBeenCalled()
     })
 
     it('should not move to previous field if current field has value', () => {


### PR DESCRIPTION
## Summary
- Ensure invalid date strings return "Invalid Date" in PR utilities
- Replace deprecated done callback in auto-advance test

## Testing
- `npm test` *(fails: auto-advance tests failing to parse input/paste and invalid input)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f91b56d083329d7002a84ba44921