### PR TITLE
Improve mobile layout width

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -881,6 +881,10 @@ body {
 
 /* Responsive adjustments */
 @media (max-width: 640px) {
+  body {
+    background: var(--bg-primary);
+  }
+
   .btn {
     min-height: 48px;
     font-size: 1.125rem;
@@ -896,15 +900,20 @@ body {
     font-size: 1.25rem;
   }
 
+  .input-segmented-container {
+    gap: clamp(0.5rem, 2.5vw, 0.75rem);
+  }
+
   .modal-content {
     margin: 0.5rem;
   }
 
   .modern-card {
-    margin: 1rem auto;
-    margin-top: 1rem;
-    width: calc(100vw - 2rem);
-    max-width: calc(28rem - 2rem);
+    margin: 0;
+    width: 100%;
+    max-width: none;
+    border-radius: 0;
+    padding: clamp(1.25rem, 4vw + 1rem, 2.25rem) clamp(1rem, 4vw, 1.75rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the main card to span the full viewport width on small screens while keeping comfortable padding
- flatten card radius on phones and tweak segmented input spacing with a responsive clamp so controls can breathe
- override the small-screen body background to the primary surface color so the full-width card no longer shows a two-tone seam

## Testing
- npm run lint *(fails: pre-existing ESLint/Stylelint warnings about console statements, jsdoc, and design token naming rules)*

------
https://chatgpt.com/codex/tasks/task_e_68d11fd29a2c8332b6a0fddbd5547af4